### PR TITLE
Fix search_items and some typos/whitespace

### DIFF
--- a/db/src/api/schema.sql
+++ b/db/src/api/schema.sql
@@ -6,9 +6,9 @@ set search_path = api, public;
 -- it is needed for the definition of the RLS policies
 drop role if exists api;
 create role api;
-grant api to current_user; -- this is a workaround for RDS where the master user does not have SUPERUSER priviliges  
+grant api to current_user; -- this is a workaround for RDS where the master user does not have SUPERUSER priviliges
 
--- redifine this type to control the user properties returned by auth endpoints
+-- redefine this type to control the user properties returned by auth endpoints
 \ir ../libs/auth/api/user_type.sql
 -- include all auth endpoints
 \ir ../libs/auth/api/all.sql

--- a/db/src/api/search_todos.sql
+++ b/db/src/api/search_todos.sql
@@ -1,4 +1,4 @@
 
 create or replace function search_items(query text) returns setof todos as $$
-select * from todos where todo like query
+select * from api.todos where todo like query
 $$ stable language sql;

--- a/db/src/libs/auth/api/signup.sql
+++ b/db/src/libs/auth/api/signup.sql
@@ -27,5 +27,5 @@ begin
     return result;
 end
 $$ security definer language plpgsql;
-
+-- by default all functions are accessible to the public, we need to remove that and define our specific access rules
 revoke all privileges on function signup(text, text, text) from public;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ### DB START
   # This is the database to which the all the other components in the stack will connect and interact with
   # (but mostly it's PostgREST that is going to be responsible for the bulk of the db traffic)
-  # Having the database in a container is very convinient in development but in production you will
+  # Having the database in a container is very convenient in development but in production you will
   # use a separate database instance, like Amazon RDS, i.e. in production this section will be
   # commented and in the .env file you will specify the ip of your separate database instance
   db:
@@ -40,16 +40,16 @@ services:
       - db:db
     environment:
       - PGRST_DB_URI=postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}
-      - PGRST_DB_SCHEMA=${DB_SCHEMA} 
+      - PGRST_DB_SCHEMA=${DB_SCHEMA}
       - PGRST_DB_ANON_ROLE=${DB_ANON_ROLE}
-      - PGRST_DB_POOL=${DB_POOL} 
-      - PGRST_JWT_SECRET=${JWT_SECRET}  
-      - PGRST_MAX_ROWS=${MAX_ROWS} 
+      - PGRST_DB_POOL=${DB_POOL}
+      - PGRST_JWT_SECRET=${JWT_SECRET}
+      - PGRST_MAX_ROWS=${MAX_ROWS}
       - PGRST_PRE_REQUEST=${PRE_REQUEST}
       - PGRST_SERVER_PROXY_URI=${SERVER_PROXY_URI}
 
   # OpenResty (Nginx + Lua) instance that sits in front of PostgREST.
-  # All the requests comming into the system are first hitting this component.
+  # All the requests coming into the system are first hitting this component.
   # After some processing/checks and transformation, the request is forwarded
   # to PostgREST down the stack.
   openresty:

--- a/tests/rest/search_todos.js
+++ b/tests/rest/search_todos.js
@@ -1,0 +1,20 @@
+import {rest_service, jwt, resetdb} from '../common.js';
+const request = require('supertest');
+const should = require("should");
+
+describe('search', function() {
+  before(function(done){ resetdb(); done(); });
+
+  it('basic', function(done) {
+    rest_service()
+      .post('/rpc/search_items')
+      .set('Authorization', 'Bearer ' + jwt)
+      .send({'query': '%item%'})
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+      .expect( r => {
+        r.body.length.should.equal(4);
+      })
+  });
+
+});


### PR DESCRIPTION
`POST ../rest/rpc/search_items` was broken because the stored proc was using the `todos` relation without prefixing with `api` schema. This fixes that and adds a REST unit test to check it.

Also cleaned up some typos and whitespace.