### PR TITLE
Issue with PUT /{ressource} when some view columns are computed

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "supertest": "^3.0.0"
   },
   "scripts": {
+    "dev": "docker-compose up --force-recreate",
+    "dev:down": "docker-compose down",
+    "psql:logs": ". .env && docker logs -f ${COMPOSE_PROJECT_NAME}_db_1",
     "test_graphql": "mocha  --no-timeouts --require babel-core/register ./tests/graphql/",
     "test_rest": "mocha --no-timeouts --require babel-core/register ./tests/rest/",
     "test_db": "node tests/bin/test_db.js",

--- a/tests/rest/write.js
+++ b/tests/rest/write.js
@@ -1,0 +1,28 @@
+import { rest_service, resetdb } from '../common'
+import should from 'should'
+
+describe('write', function () {
+  before(function (done) { resetdb(); done() })
+  after(function (done) { resetdb(); done() })
+
+  it('update a todo', function() {
+    return rest_service()
+      .put('/todos/1')
+      .withRole('webuser')
+      .send({
+        // uncommenting this will yield a 'View columns that are not columns of their base relation are not updatable.'
+        // id: null,
+        // if we don't we got a 'You must specify all columns in the payload when using PUT'
+        row_id: '1',
+        todo: 'test updated',
+        private: false,
+        mine: false,
+      })
+      .expect(r => {
+        r.body.should.equal('Object{}')
+      })
+      .expect(res => res.statusCode.should.equal(201))
+      .expect('Location', /todos\?id=eq\./);
+  });
+})
+


### PR DESCRIPTION
We either got 'View columns that are not columns of their base relation are not updatable.' or 'You must specify all columns in the payload when using PUT'.

See L.13 to L.15.